### PR TITLE
Allow absolute paths, rename a variable

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -48,16 +48,21 @@ module.exports = class Runner {
 		!Array.isArray(files) && (files = [files]);
 		files.forEach(testPath => {
 			// Root path
-			const root = path.join(process.cwd(), testPath || '.');
+			let rootPath;
+			if (path.isAbsolute(testPath)) {
+				rootPath = testPath;
+			} else {
+				rootPath = path.join(process.cwd(), testPath || '.');
+			}
 
-			if (root === process.cwd()) {
+			if (rootPath === process.cwd()) {
 				console.log(this._generateHelp(params));
 				throw new Error('Error: Test suite or file path required.');
 			}
 
 			try {
 				const self = this;
-				if (fs.statSync(root).isDirectory()) {
+				if (fs.statSync(rootPath).isDirectory()) {
 
 					/**
 					 * Add the tests to the Mocha instance
@@ -74,9 +79,9 @@ module.exports = class Runner {
 						.forEach(file => {
 							self.mocha.addFile(`${dir}${file}`);
 						});
-					}(root));
+					}(rootPath));
 				} else {
-					self.mocha.addFile(root);
+					self.mocha.addFile(rootPath);
 				}
 			} catch (e) {
 				throw new Error('Error processing files:\n' + e.message);
@@ -232,7 +237,7 @@ module.exports = class Runner {
 
 				failureBody += '‖==============================\n';
 				failureBody += `‖ ${testKey}\n`;
-				failureBody += `‖==============================\n\n`;
+				failureBody += '‖==============================\n\n';
 
 				failureBody += `- File       : ${total[testKey][0].test.file || total[testKey][0].test.parent.file}\n`;
 				failureBody += `- Passes     : ${passes[testKey].length} (${Math.round((100 / testCount * passes[testKey].length) * 100) / 100}%)\n`;


### PR DESCRIPTION
Can now pass in an array of absolute paths. Rename the variable root to rootPath as root causes some problems, https://github.com/nodejs/node/pull/1838